### PR TITLE
Correct the content submission function.

### DIFF
--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -42,14 +42,22 @@ def submit(destdir, content_store_url, content_id_base):
     for (dirpath, dirnames, filenames) in os.walk(destdir):
         for name in filenames:
             fullpath = os.path.join(dirpath, name)
-            ext = os.path.splitext(name)[1]
+            base, ext = os.path.splitext(name)
 
             if os.path.isfile(fullpath) and ext == ".json":
                 relpath = os.path.relpath(fullpath, destdir)
 
-                print("submitting [{}] ... ".format(relpath), end='')
+                content_suffix = os.path.relpath(
+                    os.path.join(dirpath, base), destdir
+                )
+                content_id = content_id_base + content_suffix
 
-                payload = dict(id=content_id_base + relpath)
+                print(
+                    "submitting [{}] as [{}] ... ".format(relpath, content_id),
+                    end=''
+                )
+
+                payload = dict(id=content_id)
 
                 with open(fullpath, "r") as inf:
                     payload["body"] = json.load(inf)

--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -47,9 +47,14 @@ def submit(destdir, content_store_url, content_id_base):
             if os.path.isfile(fullpath) and ext == ".json":
                 relpath = os.path.relpath(fullpath, destdir)
 
-                content_suffix = os.path.relpath(
-                    os.path.join(dirpath, base), destdir
-                )
+                if base == "index":
+                    full_suffix = dirpath
+                else:
+                    full_suffix = os.path.join(dirpath, base)
+
+                content_suffix = os.path.relpath(full_suffix, destdir)
+                content_suffix = content_suffix.rstrip("/.")
+
                 content_id = content_id_base + content_suffix
 
                 print(

--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -39,12 +39,12 @@ def submit(destdir, content_store_url, content_id_base):
         "Content-Type": "application/json"
     }
 
-    for (dirname, names, filenames) in os.walk(destdir):
-        for name in names:
-            fullpath = os.path.join(dirname, name)
+    for (dirpath, dirnames, filenames) in os.walk(destdir):
+        for name in filenames:
+            fullpath = os.path.join(dirpath, name)
             ext = os.path.splitext(name)[1]
 
-            if os.path.isfile(fullpath) and ext == "json":
+            if os.path.isfile(fullpath) and ext == ".json":
                 relpath = os.path.relpath(fullpath, destdir)
 
                 print("submitting [{}] ... ".format(relpath), end='')


### PR DESCRIPTION
I'd messed up the values yielded from `os.walk` on the first try. I should also correct the generated content IDs:

 * They shouldn't include the file extension.
 * "index" should be special-cased to map to the base resource.