### PR TITLE
Ensure that no content IDs have trailing slashes.

### DIFF
--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -53,9 +53,9 @@ def submit(destdir, content_store_url, content_id_base):
                     full_suffix = os.path.join(dirpath, base)
 
                 content_suffix = os.path.relpath(full_suffix, destdir)
-                content_suffix = content_suffix.rstrip("/.")
 
                 content_id = content_id_base + content_suffix
+                content_id = content_id.rstrip("/.")
 
                 print(
                     "submitting [{}] as [{}] ... ".format(relpath, content_id),


### PR DESCRIPTION
This is for consistency with deconst/mapping-service#10.