### PR TITLE
Use git instead of command-line arguments to control content submission

### DIFF
--- a/deconstrst/__init__.py
+++ b/deconstrst/__init__.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 from deconstrst.deconstrst import build, submit
+from deconstrst.config import Configuration
 
 __author__ = 'Ash Wilson'
 __email__ = 'ash.wilson@rackspace.com'
@@ -12,41 +13,26 @@ __version__ = '0.1.0'
 
 def main():
 
-    content_store_url = os.getenv("CONTENT_STORE_URL")
-    content_id_base = os.getenv("CONTENT_ID_BASE")
-
-    if args.submit:
-        missing = {}
-
-        if not content_store_url:
-            missing["CONTENT_STORE_URL"] = "Base URL of the content storage " \
-                "service."
-        if not content_id_base:
-            missing["CONTENT_ID_BASE"] = "Base URL used to generate IDs for " \
-                "content within this repository."
-
-        if missing:
-            print("Required environment variables are missing!",
-                  file=sys.stderr)
-            for var, meaning in missing.items():
-                print("  {}\t{}".format(var, meaning), file=sys.stderr)
-            sys.exit(1)
-        else:
-            if not content_store_url.endswith("/"):
-                content_store_url += "/"
-
-            if not content_id_base.endswith("/"):
-                content_id_base += "/"
+    config = Configuration(os.environ)
 
     # Lock source and destination to the same paths as the Makefile.
     srcdir, destdir = '.', '_build/deconst'
 
     status = build(srcdir, destdir)
-
-    if status != 0 or not args.submit:
+    if status != 0:
         sys.exit(status)
 
-    submit(destdir, content_store_url, content_id_base)
+    reasons = config.skip_submit_reasons()
+    if reasons:
+        print("Not submitting content to the content service because:",
+              file=sys.stderr)
+        print(file=sys.stderr)
+        for reason in reasons:
+            print(" * " + reason, file=sys.stderr)
+        print(file=sys.stderr)
+        return
+
+    submit(destdir, config.content_store_url, config.content_id_base)
 
 
 if __name__ == '__main__':

--- a/deconstrst/__init__.py
+++ b/deconstrst/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import argparse
 import os
 import sys
 
@@ -12,12 +11,7 @@ __version__ = '0.1.0'
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-s", "--submit",
-                        help="Submit results to the content store.",
-                        action="store_true")
 
-    args = parser.parse_args()
     content_store_url = os.getenv("CONTENT_STORE_URL")
     content_id_base = os.getenv("CONTENT_ID_BASE")
 

--- a/deconstrst/config.py
+++ b/deconstrst/config.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+import sh
+import re
+
+
+class Configuration:
+    """
+    Configuration settings derived from the environment and current git branch.
+    """
+
+    def __init__(self, env):
+        self.content_store_url = env.get("CONTENT_STORE_URL")
+        self.content_id_base = env.get("CONTENT_ID_BASE")
+        self.deployment_ref = re.compile(env.get("DEPLOY_REF",
+                                                 "refs/heads/master"))
+
+        try:
+            self.refname = self.sh.git("symbolic-ref", "HEAD").strip()
+        except sh.ErrorReturnCode:
+            self.refname = ""
+
+    def skip_submit_reasons(self):
+        """
+        Determine whether or not the current build should result in submission
+        to the content service. If not, return a list of reasons why it won't.
+        """
+
+        reasons = []
+
+        if not self.content_store_url:
+            reasons.append("Missing CONTENT_STORE_URL, the base URL of the "
+                           "content storage service.")
+
+        if not self.content_id_base:
+            reasons.append("Missing CONTENT_ID_BASE, the base URL used to "
+                           "generate IDs for content within this repository.")
+
+        if not self.deployment_ref.match(self.refname):
+            reasons.append(
+                "The current git ref ({}) doesn't match the deployment ref "
+                "regexp ({}).".format(self.refname,
+                                      self.deployment_ref.pattern))
+
+        return reasons
+
+    @classmethod
+    def load(cls, env):
+        """
+        Derive the current configuration from the environment.
+        """
+
+        return cls(env)

--- a/deconstrst/config.py
+++ b/deconstrst/config.py
@@ -4,19 +4,30 @@ import sh
 import re
 
 
+def _normalize(url):
+    """
+    Ensure that its argument ends with a trailing / if it's nonempty.
+    """
+
+    if url and not url.endswith("/"):
+        return url + "/"
+    else:
+        return url
+
+
 class Configuration:
     """
     Configuration settings derived from the environment and current git branch.
     """
 
     def __init__(self, env):
-        self.content_store_url = env.get("CONTENT_STORE_URL")
-        self.content_id_base = env.get("CONTENT_ID_BASE")
+        self.content_store_url = _normalize(env.get("CONTENT_STORE_URL"))
+        self.content_id_base = _normalize(env.get("CONTENT_ID_BASE"))
         self.deployment_ref = re.compile(env.get("DEPLOY_REF",
                                                  "refs/heads/master"))
 
         try:
-            self.refname = self.sh.git("symbolic-ref", "HEAD").strip()
+            self.refname = sh.git("symbolic-ref", "HEAD").strip()
         except sh.ErrorReturnCode:
             self.refname = ""
 
@@ -29,16 +40,17 @@ class Configuration:
         reasons = []
 
         if not self.content_store_url:
-            reasons.append("Missing CONTENT_STORE_URL, the base URL of the "
-                           "content storage service.")
+            reasons.append("CONTENT_STORE_URL is missing. It should be the "
+                           "base URL of the content storage service.")
 
         if not self.content_id_base:
-            reasons.append("Missing CONTENT_ID_BASE, the base URL used to "
-                           "generate IDs for content within this repository.")
+            reasons.append("CONTENT_ID_BASE is missing. It should be the base "
+                           "URL used to generate IDs for content within this "
+                           "repository.")
 
         if not self.deployment_ref.match(self.refname):
             reasons.append(
-                "The current git ref ({}) doesn't match the deployment ref "
+                "The current git ref ({}) doesn't match the DEPLOY_REF "
                 "regexp ({}).".format(self.refname,
                                       self.deployment_ref.pattern))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Jinja2==2.7.3
 MarkupSafe==0.23
 Pygments==2.0.2
 requests==2.5.3
+sh==1.11
 Sphinx==1.2.3
 sphinx-bootstrap-theme==0.4.5
 wheel==0.23.0


### PR DESCRIPTION
Rather than trying to do some kind of painful bash scripting to decide whether or not content should be submitted after a build, make the decision based on:

 1. The presence or absence of the necessary configuration environment variables.
 2. The current git branch matching a regexp.

This should keep us non-Travis specific, too.