### PR TITLE
Publish images and other static content to the CDN.

### DIFF
--- a/deconstrst/builder.py
+++ b/deconstrst/builder.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
 
+import os
+from os import path
+
+import requests
+from docutils import nodes
 from sphinx.builders.html import JSONHTMLBuilder
 from sphinx.util import jsonimpl
+from deconstrst.config import Configuration
 
 
 class DeconstJSONImpl:
@@ -42,3 +48,36 @@ class DeconstJSONBuilder(JSONHTMLBuilder):
 
     def init(self):
         JSONHTMLBuilder.init(self)
+
+        self.deconst_config = Configuration(os.environ)
+        self.should_submit = not self.deconst_config.skip_submit_reasons()
+
+    def finish(self):
+        """
+        We need to write images and static assets *first*.
+
+        Also, the search indices and so on aren't necessary.
+        """
+
+    def post_process_images(self, doctree):
+        """
+        Publish images to the content store. Modify the image reference with
+        the
+        """
+
+        JSONHTMLBuilder.post_process_images(self, doctree)
+
+        if self.should_submit:
+            for node in doctree.traverse(nodes.image):
+                node['uri'] = self._publish_entry(node['uri'])
+
+    def _publish_entry(self, srcfile):
+        # TODO guess the content-type
+
+        url = self.deconst_config.content_store_url + "assets"
+        basename = path.basename(srcfile)
+        files = {basename: open(srcfile, 'rb')}
+
+        response = requests.post(url, files=files)
+        response.raise_for_status()
+        return response.json()[basename]


### PR DESCRIPTION
Use the content service's asset API to publish images during the page build and use the CDN hrefs.