### PR TITLE
Allow documents to specify a layout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,19 @@
 *deconstrst* builds [Sphinx documentation](http://sphinx-doc.org/contents.html) into a custom JSON metadata envelope and broadcasts it to a *Content Storage* service that performs storage and indexing for presentation and search.
 
 It's intended to be used within a CI system to present content to the rest of build pipeline.
+
+## reStructuredText integration
+
+Sphinx doesn't natively have the concept of a per-page layout. To tell Deconst what layout to use for a specific page, add the following field to a field list that's the *first thing* within a page, along with any other [per-page metadata](http://sphinx-doc.org/markup/misc.html#file-wide-metadata) that's present:
+
+```rst
+:deconstlayout: this-page-layout-key
+```
+
+If this field isn't specified, a setting in your `conf.py` will be used:
+
+```python
+deconst_default_layout = "default-layout-key"
+```
+
+Finally, the preparer will fall back to `"default"` if no other key is specified.

--- a/deconstrst/builder.py
+++ b/deconstrst/builder.py
@@ -7,7 +7,11 @@ import requests
 from docutils import nodes
 from sphinx.builders.html import JSONHTMLBuilder
 from sphinx.util import jsonimpl
+from sphinx.config import Config
 from deconstrst.config import Configuration
+
+# Tell Sphinx about the deconst_default_layout key.
+Config.config_values["deconst_default_layout"] = ("default", "html")
 
 
 class DeconstJSONBuilder(JSONHTMLBuilder):
@@ -53,7 +57,8 @@ class DeconstJSONBuilder(JSONHTMLBuilder):
         """
 
         meta = self.env.metadata[pagename]
-        ctx["deconst_layout_key"] = meta.get("deconstlayout", "default")
+        ctx["deconst_layout_key"] = meta.get(
+            "deconstlayout", self.config.deconst_default_layout)
 
         super().handle_page(pagename, ctx, *args, **kwargs)
 

--- a/deconstrst/builder.py
+++ b/deconstrst/builder.py
@@ -10,39 +10,12 @@ from sphinx.util import jsonimpl
 from deconstrst.config import Configuration
 
 
-class DeconstJSONImpl:
-    """
-    Enhance the default JSON encoder by adding additional keys.
-    """
-
-    def dump(self, obj, fp, *args, **kwargs):
-        self._enhance(obj)
-        return jsonimpl.dump(obj, fp, *args, **kwargs)
-
-    def dumps(self, obj, *args, **kwargs):
-        self._enhance(obj)
-        return jsonimpl.dumps(obj, *args, **kwargs)
-
-    def load(self, *args, **kwargs):
-        return jsonimpl.load(*args, **kwargs)
-
-    def loads(self, *args, **kwargs):
-        return jsonimpl.loads(*args, **kwargs)
-
-    def _enhance(self, obj):
-        """
-        Add additional properties to "obj" to get them into the JSON.
-        """
-
-        obj["hello"] = "Sup"
-
-
 class DeconstJSONBuilder(JSONHTMLBuilder):
     """
     Custom Sphinx builder that generates Deconst-compatible JSON documents.
     """
 
-    implementation = DeconstJSONImpl()
+    implementation = jsonimpl
     name = 'deconst'
     out_suffix = '.json'
 
@@ -58,6 +31,20 @@ class DeconstJSONBuilder(JSONHTMLBuilder):
 
         Also, the search indices and so on aren't necessary.
         """
+
+    def dump_context(self, context, filename):
+        """
+        Override the default serialization code to save a derived metadata
+        envelope, instead.
+        """
+
+        envelope = {
+            "body": context["body"],
+            "title": context["title"],
+            "layout_key": "default"
+        }
+
+        super().dump_context(envelope, filename)
 
     def post_process_images(self, doctree):
         """

--- a/deconstrst/builder.py
+++ b/deconstrst/builder.py
@@ -41,10 +41,21 @@ class DeconstJSONBuilder(JSONHTMLBuilder):
         envelope = {
             "body": context["body"],
             "title": context["title"],
-            "layout_key": "default"
+            "layout_key": context["deconst_layout_key"]
         }
 
         super().dump_context(envelope, filename)
+
+    def handle_page(self, pagename, ctx, *args, **kwargs):
+        """
+        Override the default serialization code to save a derived metadata
+        envelope, instead.
+        """
+
+        meta = self.env.metadata[pagename]
+        ctx["deconst_layout_key"] = meta.get("deconstlayout", "default")
+
+        super().handle_page(pagename, ctx, *args, **kwargs)
 
     def post_process_images(self, doctree):
         """

--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -39,7 +39,7 @@ def submit(destdir, content_store_url, content_id_base):
         "Content-Type": "application/json"
     }
 
-    for (dirpath, dirnames, filenames) in os.walk(destdir):
+    for dirpath, dirnames, filenames in os.walk(destdir):
         for name in filenames:
             fullpath = os.path.join(dirpath, name)
             base, ext = os.path.splitext(name)


### PR DESCRIPTION
Adding a fieldlist to the beginning of a `.rst` file like this:

```
:deconst-layout: docs-page
```

Will result in that layout being specified in the metadata envelope.

A default layout should also be able to be set in `config.py`.